### PR TITLE
Oppdater deprecated depedencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,5 +67,5 @@ jobs:
         env:
           IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ inputs.ECR_REPOSITORY }}"
         run: |
-          echo "::set-output name=image::$IMAGE"
-          echo "::set-output name=tag::${{ inputs.IMAGE_TAG }}"
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "tag=${{ inputs.IMAGE_TAG }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,10 @@ jobs:
           mask-aws-account-id: no
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
         id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
 
       - name: Build, tag, and push image to Amazon ECR
         if: github.event.action != 'closed'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,8 +70,7 @@ jobs:
         working-directory: terraform
         id: workspace
         run: |
-          terraform workspace select $WORKSPACE \
-          || terraform workspace new $WORKSPACE
+          terraform workspace select -or-create $WORKSPACE
 
       - name: Deploy environment
         working-directory: terraform

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "REPO_NAME=$(echo ${{ github.repository }} | sed 's/bekk\///')" >> $GITHUB_ENV
 
       - name: Checkout git repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: fetch artifacts
         uses: actions/download-artifact@v3
@@ -36,15 +36,15 @@ jobs:
           mv artifact/* .
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/tf_ci_lambda_${{ env.REPO_NAME }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/lambda_review.yml
+++ b/.github/workflows/lambda_review.yml
@@ -25,18 +25,18 @@ jobs:
         run: echo "REPO_NAME=$(echo ${{ github.repository }} | sed 's/bekk\///')" >> $GITHUB_ENV
         
       - name: Checkout git repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/tf_ci_lambda_${{ env.REPO_NAME }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,1 +1,0 @@
-review.yml

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -70,8 +70,7 @@ jobs:
         working-directory: terraform
         id: workspace
         run: |
-          terraform workspace select $WORKSPACE \
-          || terraform workspace new $WORKSPACE
+          terraform workspace select -or-create $WORKSPACE
 
       - name: Deploy preview environment
         working-directory: terraform


### PR DESCRIPTION
Vi får ganske mange warnings når vi kjører våre Github Actions-workflows, som i hovedsak skyldes følgende årsaker:
- Noen script har avhengighet til `node12`, som er deprecated til fordel for `node16` ([kilde](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/))
- Å skrive ting til output ved hjelp av `::set-output` er deprecated, og må nå gjøres på en ny måte ([kilde](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
- Når vi skal lage et nytt TF-workspace til preview-miljø, så brukte vi kommandoen `terraform workspace select $WORKSPACE || terraform workspace new $WORKSPACE`, som ville gi en (ufarlig) error hvis ikke workspace fantes først gang, før det ble opprettet. Her kan vi istedenfor bruke `-or-create`-flagget slik: `terraform workspace select -or-create $WORKSPACE`
- Vi fikk warning on at Docker-passordet ikke var maskert ifm. `ecr-login`-steget, med referanse [hit](https://github.com/aws-actions/amazon-ecr-login#docker-credentials). Fulgte [beskrivelse](https://github.com/aws-actions/amazon-ecr-login#login-to-amazon-ecr-private-then-build-and-push-a-docker-image) fra deres README for hvordan det kunne fikses.

Ved å oppdatere alle script-avhengigheter og skrive om våre egen kode, så skal alle disse issuene være fikset. Jeg har i tillegg fjernet symlinken `preview.yml`, som bare pekte til `review.yml` for bakoverkompatible årsaker, men jeg kunne ikke finne noe repo som fortsatt brukte `preview.yml`.

Har testet ny PR-workflow i en frontend-app og backend-service, hvor alt kjører som før. Regner derfor med at øvrige workflows vil fungere tilsvarende.