### PR TITLE
Oppdaterer eksisterende TF-kommentar istedenfor å lage ny

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -130,6 +130,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+            })
+
+            // 2. Prepare format of the comment
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
@@ -148,12 +159,22 @@ jobs:
 
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
+            // 3. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: output
+              })
+            }
 
       - name: Terraform Plan Status for merge
         if: steps.plan-merge.outcome == 'failure'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -122,7 +122,7 @@ jobs:
         continue-on-error: true
 
       - name: Update Pull Request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: github.event.action != 'closed'
         env:
           PLAN: "terraform\n${{ steps.plan-merge.outputs.stdout }}"


### PR DESCRIPTION
Notion: https://www.notion.so/bekks/Redusere-TF-spam-i-PR-0a737319bd264b70867d067475d2259b?pvs=4

I dag så lager `review.yml`-workflowen en ny kommentar med TF-output for hver commit en gjør i en PR. Det oppleves fort som ganske mye spam og drukner andre kommentarer. Det er sjelden disse kommentarene inneholder noe av interesse under vanlig utvikling (utover preview-URL), da vi som regel ikke gjør endringer i `terraform`-mappen. Det er dermed kun snakk om endringer relatert til ny deploy.

Løsningen her er basically tatt fra dokumentasjonen til `setup-terraform` [her](https://github.com/hashicorp/setup-terraform/#usage), hvor den forsøker å finne tidligere kommenatarer laget en en bot som inneholder gitte nøkkelord, og hvis den finner en kommentar vil den i så fall oppdatere denne istedenfor å lage ny.

Se https://github.com/bekk/bekk-ansattlisten/pull/197 for hvordan det blir seende ut i en PR, hvor tidligere versjoner av kommentaren også kan hentes frem om ønskelig.