### PR TITLE
Oppdater alle action script dependencies til siste major

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -51,9 +51,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          mask-password: "true"
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set image tag in output
         id: "set-image-tag"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
         uses: webfactory/ssh-agent@v0.8.0

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -26,17 +26,17 @@ jobs:
         run: echo "REPO_NAME=$(echo ${{ github.repository }} | sed 's/bekk\///')" >> $GITHUB_ENV
 
       - name: Checkout git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: fetch artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: unbox artifacts
         run: |
           mv artifact/* .
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
         uses: webfactory/ssh-agent@v0.8.0
@@ -44,7 +44,7 @@ jobs:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/tf_ci_lambda_${{ env.REPO_NAME }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/lambda_review.yml
+++ b/.github/workflows/lambda_review.yml
@@ -25,10 +25,10 @@ jobs:
         run: echo "REPO_NAME=$(echo ${{ github.repository }} | sed 's/bekk\///')" >> $GITHUB_ENV
         
       - name: Checkout git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
         uses: webfactory/ssh-agent@v0.8.0
@@ -36,7 +36,7 @@ jobs:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/tf_ci_lambda_${{ env.REPO_NAME }}
           aws-region: ${{ inputs.AWS_REGION }}
@@ -65,7 +65,7 @@ jobs:
         continue-on-error: true
 
       - name: Update Pull Request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: github.event.action != 'closed'
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
         uses: webfactory/ssh-agent@v0.8.0


### PR DESCRIPTION
Inkluderer blant annet oppdatering av node16 -> node20 i scriptene, siden node16 er deprecated og vil etter hvert miste støtte i Github Actions (vi får varsel om det på alle workflow-kjøringer, les mer [her](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20)). Skal ikke ellers være noen funksjonelle endringer slik vi bruker de, og har testet PR-workflowen at den fortsatt fungerer som før. Utover det tar vi det som det kommer 🤠 