### PR TITLE
Oppgrader webfactory/ssh-agent til v0.9.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/lambda_review.yml
+++ b/.github/workflows/lambda_review.yml
@@ -31,7 +31,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -37,7 +37,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.8.0
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
Release notes: https://github.com/webfactory/ssh-agent/releases/tag/v0.9.0

Ny versjon bruker `node20` istedenfor `node18`, som er deprecated og gir warning på Github ved kjøring av workflows.