### PR TITLE
Add concurrency controls to prevent Terraform state lock conflicts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,9 @@ jobs:
   terraform:
     name: Run terraform
     runs-on: ubuntu-latest
+    concurrency:
+      group: terraform-${{ github.repository }}-${{ inputs.TERRAFORM_WORKSPACE }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout git repo

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -20,6 +20,9 @@ jobs:
   terraform:
     name: Run terraform
     runs-on: ubuntu-latest
+    concurrency:
+      group: terraform-${{ github.repository }}-lambda-deploy
+      cancel-in-progress: false
 
     steps:
       - name: Set repository name

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,7 +29,7 @@ jobs:
     name: Run terraform
     runs-on: ubuntu-latest
     concurrency:
-      group: terraform-${{ github.repository }}-${{ inputs.TERRAFORM_WORKSPACE }}
+      group: terraform-${{ github.repository }}-${{ github.head_ref }}
       cancel-in-progress: false
 
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -28,6 +28,9 @@ jobs:
   terraform:
     name: Run terraform
     runs-on: ubuntu-latest
+    concurrency:
+      group: terraform-${{ github.repository }}-${{ inputs.TERRAFORM_WORKSPACE }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout git repo


### PR DESCRIPTION
forhindrer at to deploy-jobber kjører samtidig på samme repo+branch kombo ved å lage en concurrency group.

har satt den til å vente, heller enn å avbryte forrige, fordi det krever litt større endringer å sikre seg at deploy slipper låsen

testet på en branch her: https://github.com/bekk/bekk-timekeeper-app/actions?query=branch%3Atest-ci+