### PR TITLE
Ikke eksekver inputs.TERRAFORM_WORKSPACE

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Set terraform workspace variable
         id: tf-workspace
+        env:
+          TERRAFORM_WORKSPACE: ${{ inputs.TERRAFORM_WORKSPACE }}
         run: |
           sanitize_tag_part() {
             printf '%s' "$1" \
@@ -76,7 +78,13 @@ jobs:
               | sed -E 's|[^a-z0-9-]+|-|g; s/-+$//; s/^-+//; s/-+/-/g'
           }
 
-          printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "${{ inputs.TERRAFORM_WORKSPACE }}")" >> "$GITHUB_ENV"
+          if [ "$TERRAFORM_WORKSPACE" = '$GITHUB_HEAD_REF' ]; then
+            unsanitized_workspace_name="$GITHUB_HEAD_REF"
+          else
+            unsanitized_workspace_name="$TERRAFORM_WORKSPACE"
+          fi
+
+          printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "$unsanitized_workspace_name")" >> "$GITHUB_ENV"
 
       - name: Create and change Terraform workspace
         working-directory: terraform

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,13 +78,7 @@ jobs:
               | sed -E 's|[^a-z0-9-]+|-|g; s/-+$//; s/^-+//; s/-+/-/g'
           }
 
-          if [ "$TERRAFORM_WORKSPACE" = '$GITHUB_HEAD_REF' ]; then
-            unsanitized_workspace_name="$GITHUB_HEAD_REF"
-          else
-            unsanitized_workspace_name="$TERRAFORM_WORKSPACE"
-          fi
-
-          printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "$unsanitized_workspace_name")" >> "$GITHUB_ENV"
+          printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "$TERRAFORM_WORKSPACE")" >> "$GITHUB_ENV"
 
       - name: Create and change Terraform workspace
         working-directory: terraform

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -76,7 +76,13 @@ jobs:
               | sed -E 's|[^a-z0-9-]+|-|g; s/-+$//; s/^-+//; s/-+/-/g'
           }
 
-          printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "${{ inputs.TERRAFORM_WORKSPACE }}")" >> "$GITHUB_ENV"
+          if [ "$TERRAFORM_WORKSPACE" = '$GITHUB_HEAD_REF' ]; then
+            unsanitized_workspace_name="$GITHUB_HEAD_REF"
+          else
+            unsanitized_workspace_name="$TERRAFORM_WORKSPACE"
+          fi
+
+          printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "$unsanitized_workspace_name")" >> "$GITHUB_ENV"
 
       - name: Create and change Terraform workspace
         working-directory: terraform

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -78,11 +78,14 @@ jobs:
               | sed -E 's|[^a-z0-9-]+|-|g; s/-+$//; s/^-+//; s/-+/-/g'
           }
 
+          printf '::notice::tfw %s\n' "$TERRAFORM_WORKSPACE"
+          printf '::notice::gh %s\n' "$GITHUB_HEAD_REF"
           if [ "$TERRAFORM_WORKSPACE" = '$GITHUB_HEAD_REF' ]; then
             unsanitized_workspace_name="$GITHUB_HEAD_REF"
           else
             unsanitized_workspace_name="$TERRAFORM_WORKSPACE"
           fi
+          printf '::notice::%s\n' "$unsanitized_workspace_name"
 
           printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "$unsanitized_workspace_name")" >> "$GITHUB_ENV"
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -78,14 +78,11 @@ jobs:
               | sed -E 's|[^a-z0-9-]+|-|g; s/-+$//; s/^-+//; s/-+/-/g'
           }
 
-          printf '::notice::tfw %s\n' "$TERRAFORM_WORKSPACE"
-          printf '::notice::gh %s\n' "$GITHUB_HEAD_REF"
           if [ "$TERRAFORM_WORKSPACE" = '$GITHUB_HEAD_REF' ]; then
             unsanitized_workspace_name="$GITHUB_HEAD_REF"
           else
             unsanitized_workspace_name="$TERRAFORM_WORKSPACE"
           fi
-          printf '::notice::%s\n' "$unsanitized_workspace_name"
 
           printf 'WORKSPACE=%s\n' "$(sanitize_tag_part "$unsanitized_workspace_name")" >> "$GITHUB_ENV"
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Set terraform workspace variable
         id: tf-workspace
+        env:
+          TERRAFORM_WORKSPACE: ${{ inputs.TERRAFORM_WORKSPACE }}
         run: |
           sanitize_tag_part() {
             printf '%s' "$1" \


### PR DESCRIPTION
TERRAFORM_WORKSPACE var strengen `$GITHUB_HEAD_REF`, som så ble evaluert
av runneren. Det er vanskelig å se for seg at det kunne blitt utnyttet
til å gjøre noe man ikke uansett kunne gjort ved å redigere
github-workflowene i target-repoet, men føltes uansett ganske skittent.

Byttet til å ikke faktisk evaluere teksten, bare sammenligne med den
hardkodede strengen '$GITHUB_HEAD_REF', som er det eneste andre enn
'prod' eller 'dev' som blir brukt noe sted, og i så fall lese ut
GITHUB_HEAD_REF selv.

Skal ikke trenge noen endringer i andre repoer. En alternativ løsning
kunne vært at default-verdien var $GITHUB_HEAD_REF, så kunne vi sluppet
sammenligningen med den hardkodede strengen, men da måtte vi
oppdatert de andre repoene og det ville jeg ikke.

Test-PR: https://github.com/bekk/bekkno-v2/pull/690