### PR TITLE
Oppdater versjoner og standardiser workflows

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -9,17 +9,17 @@ on:
         required: false
         default: "."
       format-check:
-        description: "Enable to run format check, currently using csharpier. Before enabling this check, make sure you have installed csharpier as a dotnet tool (`dotnet tool install csharpier`)."
+        description: "Enable to run format check, currently using csharpier. Before enabling, install csharpier as a dotnet tool (`dotnet tool install csharpier`)."
         type: boolean
         required: true
       dotnet-test:
-        description: "Enable to run `dotnet test`. Before enabling this check, make sure you have a test project in the solution with at least 1 test."
+        description: "Enable to run `dotnet test`. Before enabling, set up a test project in the solution with at least 1 test."
         type: boolean
         required: true
 
 jobs:
   backend-checks:
-    name: format · test
+    name: Backend checks
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,0 +1,36 @@
+name: Backend checks
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        required: false
+        default: "."
+      format-check:
+        description: "Enable to run format check, currently using csharpier. Before enabling this check, make sure you have installed csharpier as a dotnet tool (`dotnet tool install csharpier`)."
+        type: boolean
+        required: true
+      dotnet-test:
+        description: "Enable to run `dotnet test`. Before enabling this check, make sure you have a test project in the solution with at least 1 test."
+        type: boolean
+        required: true
+
+jobs:
+  backend-checks:
+    name: format · test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run format-check
+        if: ${{ !cancelled() && inputs.format-check }}
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          dotnet tool restore
+          dotnet csharpier check .
+
+      - name: Run dotnet-test
+        if: ${{ !cancelled() && inputs.dotnet-test }}
+        working-directory: ${{ inputs.working-directory }}
+        run: dotnet test

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       working-directory:
+        description: "Path to service relative to root, without trailing slash. Must contain a global.json file specifying the required .NET SDK version."
         type: string
         required: false
         default: "."
@@ -20,17 +21,27 @@ jobs:
   backend-checks:
     name: format · test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Run format-check
-        if: ${{ !cancelled() && inputs.format-check }}
-        working-directory: ${{ inputs.working-directory }}
+      - uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: ${{ inputs.working-directory }}/global.json
+          cache: ${{ hashFiles('**/packages.lock.json') != '' }}
+          cache-dependency-path: '**/packages.lock.json'
+
+      - name: Install dependencies
         run: |
           dotnet tool restore
-          dotnet csharpier check .
+          dotnet restore --locked-mode
+
+      - name: Run format-check
+        if: ${{ !cancelled() && inputs.format-check }}
+        run: dotnet csharpier check .
 
       - name: Run dotnet-test
         if: ${{ !cancelled() && inputs.dotnet-test }}
-        working-directory: ${{ inputs.working-directory }}
-        run: dotnet test
+        run: dotnet test --no-restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ inputs.AWS_REGION }}
-          mask-aws-account-id: no
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   terraform:
+    environment: ${{ inputs.TERRAFORM_WORKSPACE }}
     name: Run terraform
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -1,0 +1,47 @@
+name: Frontend checks
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        required: false
+        default: "."
+      format-check:
+        description: "Enable to run `npm run format-check`. Before enabling this check, make sure you have set up the `format-check` script in package.json."
+        type: boolean
+        required: true
+      lint-check:
+        description: "Enable to run `npm run lint-check`. Before enabling this check, make sure you have set up the `lint-check` script in package.json."
+        type: boolean
+        required: true
+      type-check:
+        description: "Enable to run `npm run type-check`. Before enabling this check, make sure you have set up the `type-check` script in package.json."
+        type: boolean
+        required: true
+
+jobs:
+  frontend-checks:
+    name: format · lint · type
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Run format-check
+        if: ${{ !cancelled() && inputs.format-check }}
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run format-check
+
+      - name: Run lint-check
+        if: ${{ !cancelled() && inputs.lint-check }}
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run lint-check
+
+      - name: Run type-check
+        if: ${{ !cancelled() && inputs.type-check }}
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run type-check

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     inputs:
       working-directory:
+        description: "Path to application relative to root, without trailing slash. Must contain a .nvmrc file specifying the required node version."
         type: string
         required: false
         default: "."
@@ -24,24 +25,29 @@ jobs:
   frontend-checks:
     name: format · lint · type
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ${{ inputs.working-directory }}/.nvmrc
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
       - name: Install dependencies
-        working-directory: ${{ inputs.working-directory }}
         run: npm ci
 
       - name: Run format-check
         if: ${{ !cancelled() && inputs.format-check }}
-        working-directory: ${{ inputs.working-directory }}
         run: npm run format-check
 
       - name: Run lint-check
         if: ${{ !cancelled() && inputs.lint-check }}
-        working-directory: ${{ inputs.working-directory }}
         run: npm run lint-check
 
       - name: Run type-check
         if: ${{ !cancelled() && inputs.type-check }}
-        working-directory: ${{ inputs.working-directory }}
         run: npm run type-check

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -9,21 +9,21 @@ on:
         required: false
         default: "."
       format-check:
-        description: "Enable to run `npm run format-check`. Before enabling this check, make sure you have set up the `format-check` script in package.json."
+        description: "Enable to run `npm run format-check`. Before enabling, set up the `format-check` script in package.json."
         type: boolean
         required: true
       lint-check:
-        description: "Enable to run `npm run lint-check`. Before enabling this check, make sure you have set up the `lint-check` script in package.json."
+        description: "Enable to run `npm run lint-check`. Before enabling, set up the `lint-check` script in package.json."
         type: boolean
         required: true
       type-check:
-        description: "Enable to run `npm run type-check`. Before enabling this check, make sure you have set up the `type-check` script in package.json."
+        description: "Enable to run `npm run type-check`. Before enabling, set up the `type-check` script in package.json."
         type: boolean
         required: true
 
 jobs:
   frontend-checks:
-    name: format · lint · type
+    name: Frontend checks
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -31,25 +31,25 @@ jobs:
         run: printf 'REPO_NAME=%s\n' "$(printf '%s' "$GITHUB_REPOSITORY" | sed 's/bekk\///')" >> "$GITHUB_ENV"
 
       - name: Checkout git repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: unbox artifacts
         run: |
           mv artifact/* .
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/tf_ci_lambda_${{ env.REPO_NAME }}
           aws-region: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/lambda_review.yml
+++ b/.github/workflows/lambda_review.yml
@@ -27,18 +27,18 @@ jobs:
         run: printf 'REPO_NAME=%s\n' "$(printf '%s' "$GITHUB_REPOSITORY" | sed 's/bekk\///')" >> "$GITHUB_ENV"
         
       - name: Checkout git repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.BEKK_BASEN_TERRAFORM_LAMBDA_MODULE_SSH_PRIVATE_KEY }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/tf_ci_lambda_${{ env.REPO_NAME }}
           aws-region: ${{ inputs.AWS_REGION }}
@@ -67,7 +67,7 @@ jobs:
         continue-on-error: true
 
       - name: Update Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event.action != 'closed'
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,0 +1,31 @@
+name: Release notification
+
+on:
+  workflow_call:
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+
+jobs:
+  slack-notification:
+    name: Slack notification
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'released'
+    steps:
+      - name: Send notification
+        uses: slackapi/slack-github-action@v3
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Ny release i ${{github.event.repository.name}}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "<${{ env.REPO_URL }}|${{ env.REPO_NAME }}>: ${{ env.RELEASE_NAME }} (<${{ env.REPO_URL }}/releases/tag/${{ env.RELEASE_TAG }}|#${{ env.RELEASE_TAG }}>)"

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -15,17 +15,24 @@ jobs:
       - name: Send notification
         uses: slackapi/slack-github-action@v3
         env:
-          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           REPO_NAME: ${{ github.event.repository.name }}
+          REPO_URL: ${{ github.event.repository.html_url }}
           RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "Ny release i ${{ env.REPO_NAME }}"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "<${{ env.REPO_URL }}|${{ env.REPO_NAME }}>: ${{ env.RELEASE_NAME }} (<${{ env.REPO_URL }}/releases/tag/${{ env.RELEASE_TAG }}|#${{ env.RELEASE_TAG }}>)"
+            {
+              "text": "Ny release i ${{ env.REPO_NAME }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(format('<{0}|{1}>: {2} (<{3}|#{4}>)', env.REPO_URL, env.REPO_NAME, env.RELEASE_NAME, env.RELEASE_URL, env.RELEASE_TAG)) }}
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -23,7 +23,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "Ny release i ${{github.event.repository.name}}"
+            text: "Ny release i ${{ env.REPO_NAME }}"
             blocks:
               - type: "section"
                 text:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Set up SSH key for custom terraform module
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -153,7 +153,7 @@ jobs:
         continue-on-error: true
 
       - name: Update Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event.action != 'closed'
         env:
           PLAN: "terraform\n${{ steps.plan-merge.outputs.stdout }}"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@ Reusable GitHub Actions workflows for internal use
 
 ## Workflows
 
+### backend-checks.yml
+Run format check (currently csharpier) and dotnet tests
+
+Inputs:
+- working-directory
+  default: "."
+- format-check
+- dotnet-test
+
+### frontend-checks.yml
+Run npm scripts for checking format, lint and types
+
+Inputs:
+- working-directory
+  default: "."
+- format-check
+- lint-check
+- type-check
+
 ### build.yml
 Build and push docker image to AWS ECR
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Secrets:
 - AWS_SECRET_ACCESS_KEY
 - SSH_PRIVATE_KEY
 
+### release-notification.yml
+Send Slack message to webhook with release information
+
+Secrets:
+- SLACK_WEBHOOK_URL
+
 ### lambda_review.yml
 Review Lambda with Terraform
 


### PR DESCRIPTION
Notion: [Kjør tester i CI på PR](https://www.notion.so/bekks/Kj-r-tester-i-CI-p-PR-3586bd30854180bbab93f2bfa89497b1?source=copy_link)

- 45a5629: Oppdaterer alle eksisterende avhengigheter til siste major-versjon
- b3e784f: Lager en felles `release-notification` workflow som sender Slack-varsel til webhook ved nye releaser, istedenfor at denne er duplisert i hvert eneste repo. Guarder med sjekk på event og action, siden vi eksplisitt forsøker å hente ut `release.name` og `release.tag_name` i meldingen, som ikke vil fungere i andre tilfeller. Kan argumentere for at dette kunne vært argument inn til metoden, men holdt det enkelt i denne omgang. Fjernet også `er publisert!` postfixet i meldingen.
- a6874a6: Et forsøk på å standardisere alt som er felles av workflows rundtom i repoene våre for frontend og backend. Det gjelder sjekk på lint, format og typer i frontend, og tester og format/csharpier i backend. Håpet er å gjøre ting mer likt, samt gjøre det enklere å vedlikeholde og oppdatere fremover ved endringer. Det er fortsatt plug-and-play med hver workflow, så det er ikke påkrevd å bruke i noen repo.
- 14e84ee: Setter `environment` på deploy-workflow brukt for dev og prod. Gjør at vi får mer visuell oversikt over siste deploy fra repoet sin hovedside (som på https://github.com/bekk/bekk-basen-entra), men gir også støtte for mer kontroll og sjekker hvis vi ønsker/trenger det.
- 8330e30: Bruker `setup-node` og `setup-dotnet` for å angi spesifikk versjon av node og dotnet, basert på konvensjonell bruk av `.nvmrc` og `global.json` i repoene. I tillegg er det aktivert støtte caching av avhengigheter for både frontend og bakcend.

Valgte å gjøre input-valgene for sjekkene påkrevd, slik at du _må_ ta stilling til hver av dem, for å gjøre ting mer synlig og eksplisitt. Alternativt kunne alt vært default `false`, slik at du kun sjekket på det du optet inn på, men det er pros & cons.