### PR TITLE
Fiks nedlasting av artefakt etter oppgradering til download-artifact@v8

### DIFF
--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -33,12 +33,11 @@ jobs:
       - name: Checkout git repo
         uses: actions/checkout@v6
 
-      - name: fetch artifacts
+      - name: Download artifact
         uses: actions/download-artifact@v8
-
-      - name: unbox artifacts
-        run: |
-          mv artifact/* .
+        with:
+          name: artifact
+          path: .
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
download-artifact@v8 endret oppførsel slik at artefakten ikke lenger havner i ./artifact/ når den lastes ned uten navn. Da feiler steget "unbox artifacts" med "mv: cannot stat 'artifact/*'".

Spesifiser name og path eksplisitt slik at innholdet legges deterministisk i .-mappa, som også gjør at vi kan fjerne unbox-steget.

Se https://github.com/bekk/bekk-lambda-sanity-backup/pull/15 for å se det i aksjon. Upload-stegene til rds-backup og rds-replicator er like som sanity-backup, så antar samme problem og løsning gjelder alle.